### PR TITLE
Remove HTML boilerplate, add contract links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,6 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>The TAO</title>
-  </head>
-  <body>
-    <pre>
+<!doctype html>
+<title>The TAO</title>
+<pre>
 
 THE TRULY AUTONOMOUS ORGANIZATION
 =================================
@@ -112,7 +108,8 @@ An ad-hoc ASCII art diagram of the structure described above:
 SOURCE CODE
 ===========
 
-The source code can be found at <a href="https://github.com/ryepdx/the-tao">https://github.com/ryepdx/the-tao</a>.
+The source code can be found at
+<a href="https://github.com/ryepdx/the-tao">https://github.com/ryepdx/the-tao</a>.
 
 
 DEPLOYMENT
@@ -139,14 +136,10 @@ TheTAOFactory ABI:
 CONTRACT LISTING
 ================
 
-* <a href="">DSEasyMultisig</a>
-* <a href="">DSBasicAuthority</a>
-* <a href="">DSTokenFrontend</a>
-* <a href="">DSTokenController</a>
-* <a href="">DSApprovalDB</a>
-* <a href="">DSBalanceDB</a>
-* <a href="">DSTokenSupplyManager</a>
-
-    </pre>
-  </body>
-</html>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/gov/easy_multisig.sol">DSEasyMultisig</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/auth/basic_authority.sol">DSBasicAuthority</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/token/frontend.sol">DSTokenFrontend</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/token/controller.sol">DSTokenController</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/data/approval_db.sol">DSApprovalDB</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/data/balance_db.sol">DSBalanceDB</a>
+* <a href="https://github.com/nexusdev/dappsys/blob/develop/contracts/token/supply_manager.sol">DSTokenSupplyManager</a>


### PR DESCRIPTION
Just in case you weren't aware that the HTML5 standard has liberated us from all those redundant boilerplate tags once and for all. :smile_cat: 